### PR TITLE
fix for tailwindcss just-in-time mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,10 @@ const plugin = require('tailwindcss/plugin')
 
 module.exports = plugin(function({ addUtilities, e }) {
   addUtilities({
-    '.\?': {
+    [`.${e('?')}`]: {
       'animation': `${e('?')}wobble 0.5s ease-in-out alternate infinite`
     },
-    '@keyframes \\?wobble': {
+    [`@keyframes ${e('?')}wobble`]: {
       '0%': {
         'box-shadow': 'inset 4px 4px rgb(236, 15, 170), inset -4px -4px rgb(236, 15, 170)'
       },


### PR DESCRIPTION
For this plugin to function when using tailwindcss in just-in-time mode, the utility key names containing the `?` must be escaped using tailwindcss's `e` helper in order for the just-in-time engine to correctly preserve the css.

Fixes #3 