### PR TITLE
build: add tailwind as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "bugs": {
     "url": "https://github.com/GavinJoyce/tailwindcss-question-mark/issues"
   },
-  "homepage": "https://github.com/GavinJoyce/tailwindcss-question-mark#readme"
+  "homepage": "https://github.com/GavinJoyce/tailwindcss-question-mark#readme",
+  "peerDependencies": {
+    "tailwindcss": ">=2.0.0"
+  }
 }


### PR DESCRIPTION
Seems this plugin is broken on [play.tailwindcss.com](play.tailwindcss.com). Not entirely sure if it will help, but added the missing peer dependency so we can test it.