### PR TITLE
use outline in additon to box-shadow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-question-mark",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A plugin that provides a helpful `?` dev time utilit",
   "main": "src/index.js",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,19 @@ const plugin = require('tailwindcss/plugin')
 module.exports = plugin(function({ addUtilities, e }) {
   addUtilities({
     [`.${e('?')}`]: {
-      'animation': `${e('?')}wobble 0.5s ease-in-out alternate infinite`
+      'outline-style': 'solid',
+      'animation': `${e('?')}wobble 0.6s ease-in-out alternate infinite`
     },
     [`@keyframes ${e('?')}wobble`]: {
       '0%': {
-        'box-shadow': 'inset 4px 4px rgb(236, 15, 170), inset -4px -4px rgb(236, 15, 170)'
+        'outline-width': '4px',
+        'outline-color': '#f16bc9',
+        'box-shadow': 'inset 4px 4px #f16bc9, inset -4px -4px #f16bc9'
       },
       '100%': {
-        'box-shadow': 'inset 8px 8px rgb(236, 15, 170), inset -8px -8px rgb(236, 15, 170)'
+        'outline-width': '6px',
+        'outline-color': '#f71fb6',
+        'box-shadow': 'inset 6px 6px #f71fb6, inset -6px -6px #f71fb6'
       },
     }
   });


### PR DESCRIPTION
This makes it easier to identify the element when it has no padding:

Before:

<img width="1644" alt="Screenshot 2023-06-22 at 12 31 22" src="https://github.com/GavinJoyce/tailwindcss-question-mark/assets/2526/c0f055ed-0db0-46e4-b83f-0a92dee84688">

After:

<img width="1640" alt="Screenshot 2023-06-22 at 12 31 30" src="https://github.com/GavinJoyce/tailwindcss-question-mark/assets/2526/fa4e88d6-1200-4aed-97d9-cd9d2e5b85c3">
